### PR TITLE
Fixing SSH-Key upload upon Linode Creation

### DIFF
--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -15,7 +15,13 @@ module VagrantPlugins
         end
 
         def call(env)
-          ssh_key_id = [env[:ssh_key_id]]
+          ssh_key_id = env[:machine].config.ssh.private_key_path
+          ssh_key_id = ssh_key_id[0] if ssh_key_id.is_a?(Array)
+
+          if ssh_key_id
+            pubkey = File.read( File.expand_path( "#{ssh_key_id}.pub" ) )
+          end
+
           if @machine.provider_config.root_pass
             root_pass = @machine.provider_config.root_pass
 	  else
@@ -67,7 +73,7 @@ module VagrantPlugins
               :label => 'Vagrant Disk Distribution ' + distribution_id.to_s + ' Linode ' + result['linodeid'].to_s,
               :type => 'ext4',
               :size => 1024,
-              :rootSSHKey => ssh_key_id,
+              :rootSSHKey => pubkey,
 	      :rootPass => root_pass
             )
           elsif image_id
@@ -75,7 +81,7 @@ module VagrantPlugins
               :linodeid => result['linodeid'],
               :imageid => image_id,
               :size => 1024,
-              :rootSSHKey => ssh_key_id,
+              :rootSSHKey => pubkey,
 	      :rootPass => root_pass
             )
           end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure('2') do |config|
   config.omnibus.chef_version = :latest
 
   config.ssh.username = 'tester'
-  config.ssh.private_key_path = 'test_id_rsa'
+  config.ssh.private_key_path = './test_id_rsa'
 
   config.vm.synced_folder '.', '/vagrant', :disabled => true
 


### PR DESCRIPTION
Adding ssh-key upload to action/create through path obtained from the configuration. Starting to work on private key usage on access!
