### PR TITLE
Add job to set hostname

### DIFF
--- a/lib/vagrant-linode/actions.rb
+++ b/lib/vagrant-linode/actions.rb
@@ -5,6 +5,7 @@ require 'vagrant-linode/actions/power_off'
 require 'vagrant-linode/actions/power_on'
 require 'vagrant-linode/actions/rebuild'
 require 'vagrant-linode/actions/reload'
+require 'vagrant-linode/actions/setup_hostname'
 require 'vagrant-linode/actions/setup_user'
 require 'vagrant-linode/actions/setup_sudo'
 require 'vagrant-linode/actions/setup_key'
@@ -100,6 +101,7 @@ module VagrantPlugins
               b.use Create
               b.use SetupSudo
               b.use SetupUser
+              b.use SetupHostname
               b.use provision
             end
           end
@@ -148,6 +150,7 @@ module VagrantPlugins
               b.use Rebuild
               b.use SetupSudo
               b.use SetupUser
+              b.use SetupHostname
               b.use provision
             when :not_created
               env[:ui].info I18n.t('vagrant_linode.info.not_created')

--- a/lib/vagrant-linode/actions/setup_hostname.rb
+++ b/lib/vagrant-linode/actions/setup_hostname.rb
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+module VagrantPlugins
+	module Linode
+		module Actions
+			class SetupHostname
+
+				def initialize(app, env)
+					@app 	 = app
+					@machine = env[:machine]
+					@logger	 = Log4r::Logger.new('vagrant::linode::setup_hostname')
+				end
+
+				def call(env)
+					# Check if setup is enabled
+					return @app.call(env) unless @machine.provider_config.setup?
+
+					# Set Hostname
+					if @machine.config.vm.hostname
+						env[:ui].info I18n.t('vagrant_linode.info.modifying_host', name: @machine.config.vm.hostname)
+
+						@machine.communicate.execute(<<-BASH)
+							sudo echo -n #{@machine.config.vm.hostname} > /etc/hostname;
+							sudo hostname -F /etc/hostname
+						BASH
+					end
+				end
+			end
+		end
+	end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -17,6 +17,7 @@ en:
       reloading: "Rebooting the linode..."
       creating_user: "Creating user account: %{user}..."
       modifying_sudo: "Modifying sudoers file to remove tty requirement..."
+      modifying_host: "Modifying hostname: %{name}..."
       using_key: "Using existing SSH key: %{name}"
       creating_key: "Creating new SSH key: %{name}..."
       trying_rsync_install: "Rsync not found, attempting to install with yum..."


### PR DESCRIPTION
Allows vagrant to set hostname on initial setup, and rebuilds.

Addressing -- https://github.com/displague/vagrant-linode/issues/21