### PR TITLE
switch from rick/linode to akerl/linodeapi gem

### DIFF
--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -98,16 +98,16 @@ module VagrantPlugins
               label: 'Vagrant Disk Distribution ' + distribution_id.to_s + ' Linode ' + result['linodeid'].to_s,
               type: 'ext4',
               size: xvda_size,
-              rootSSHKey: pubkey,
-              rootPass: root_pass
+              rootsshkey: pubkey,
+              rootpass: root_pass
             )
           elsif image_id
             disk = @client.linode.disk.createfromimage(
               linodeid: result['linodeid'],
               imageid: image_id,
               size: xvda_size,
-              rootSSHKey: pubkey,
-              rootPass: root_pass
+              rootsshkey: pubkey,
+              rootpass: root_pass
             )
 
             swap = @client.linode.disk.create(

--- a/lib/vagrant-linode/helpers/client.rb
+++ b/lib/vagrant-linode/helpers/client.rb
@@ -1,5 +1,5 @@
 require 'vagrant-linode/helpers/result'
-require 'linode'
+require 'linodeapi'
 require 'json'
 require 'vagrant/util/retryable'
 
@@ -20,8 +20,8 @@ module VagrantPlugins
               fail 'not ready' if result['host_finish_dt'] > ''
             end
           end
-          linodeapi = ::Linode.new(api_key: @machine.provider_config.token,
-                                   api_url: @machine.provider_config.api_url || nil)
+          linodeapi = ::LinodeAPI::Raw.new(apikey: @machine.provider_config.token,
+				      endpoint: @machine.provider_config.api_url || nil)
           # linodeapi.wait_for_event = wait_for_event
           # linodeapi.extend wait_for_event
         end
@@ -33,7 +33,7 @@ module VagrantPlugins
         def initialize(machine)
           @logger = Log4r::Logger.new('vagrant::linode::apiclient')
           @config = machine.provider_config
-          @client = ::Linode.new(api_key: @config.token)
+	  @client = ::LinodeAPI::Raw.new(apikey: @config.token, endpoint: @config.api_url || nil)
         end
 
         attr_reader :client

--- a/vagrant-linode.gemspec
+++ b/vagrant-linode.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://www.github.com/displague/vagrant-linode'
   gem.summary       = gem.description
 
-  gem.add_runtime_dependency 'linode'
+  gem.add_runtime_dependency 'linodeapi'
   gem.add_runtime_dependency 'json'
   gem.add_runtime_dependency 'log4r'
 


### PR DESCRIPTION
The akerl/linodeapi gem follows the API directly.  If Linode makes an upstream change in the API it will be immediately available for use.  With the existing gem a PR must be made in order for the Linode class to include support for new API features.

This needs to go through more testing and needs another visual pass for mixed case variables (which must now be lowercased).