### PR TITLE
fix image -> distribution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Please note the following:
 **Supported Configuration Attributes**
 
 The following attributes are available to further configure the provider:
-- `provider.distribution` - A string representing the image to use when creating a
-   new linode (e.g. `Debian 7.5`). The available options may
+- `provider.distribution` - A string representing the distribution to use when
+   creating a new linode (e.g. `Debian 7.5`). The available options may
    be found on Linode's new linode [form](https://www.linode.com/distributions).
    It defaults to `Ubuntu 14.04 LTS`.
 - `provider.datacenter` - A string representing the region to create the new

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Please note the following:
 **Supported Configuration Attributes**
 
 The following attributes are available to further configure the provider:
-- `provider.image` - A string representing the image to use when creating a
+- `provider.distribution` - A string representing the image to use when creating a
    new linode (e.g. `Debian 7.5`). The available options may
    be found on Linode's new linode [form](https://www.linode.com/distributions).
    It defaults to `Ubuntu 14.04 LTS`.


### PR DESCRIPTION
When I set provider.image, it tried to look it up as an image and I always ended up w/ an Ubuntu 14.04 instance