### PR TITLE
actions/create.rb: Expose hooks for display group

### DIFF
--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -137,9 +137,13 @@ module VagrantPlugins
           label = label || @machine.name if @machine.name != 'default'
           label = label || get_server_name
 
+          group = @machine.provider_config.group
+          group = "" if @machine.provider_config.group == false
+
           result = @client.linode.update(
             linodeid: result['linodeid'],
-            label: label
+            label: label,
+            lpm_displaygroup: group
           )
 
           env[:ui].info I18n.t('vagrant_linode.info.booting', linodeid: result['linodeid'])

--- a/lib/vagrant-linode/config.rb
+++ b/lib/vagrant-linode/config.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :swap_size
       attr_accessor :kernel_id
       attr_accessor :label
+      attr_accessor :group
 
       alias_method :setup?, :setup
 
@@ -33,6 +34,7 @@ module VagrantPlugins
         @swap_size          = UNSET_VALUE
         @kernel_id          = UNSET_VALUE
         @label              = UNSET_VALUE
+        @group              = UNSET_VALUE
       end
 
       def finalize!
@@ -50,6 +52,7 @@ module VagrantPlugins
         @swap_size          = '256' if @swap_size == UNSET_VALUE
         @kernel_id          = '138' if @kernel_id == UNSET_VALUE
         @label              = false if @label == UNSET_VALUE
+        @group              = false if @group == UNSET_VALUE
       end
 
       def validate(machine)

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -2,13 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.require_plugin('vagrant-linode')
-Vagrant.require_plugin('vagrant-omnibus')
 
 Vagrant.configure('2') do |config|
-  config.omnibus.chef_version = :latest
 
-  config.ssh.username = 'tester'
-  config.ssh.private_key_path = './test_id_rsa'
+  config.ssh.username = 'rawrus'
+  config.ssh.private_key_path = '~/.ssh/draugr'
 
   config.vm.synced_folder '.', '/vagrant', disabled: true
 
@@ -16,9 +14,9 @@ Vagrant.configure('2') do |config|
     override.vm.box = 'linode'
     override.vm.box_url = 'https://github.com/displague/vagrant-linode/raw/master/box/linode.box'
     provider.token = ENV['LINODE_TOKEN']
-    provider.ssh_key_name = 'Test Key'
+
     provider.distribution = 'Ubuntu 14.04 LTS'
-    provider.datacenter = 'newark'
+    provider.ssh_key_name = 'Test Key'
     provider.plan = '1024'
 
     # Disk Image Sizes (Optional configuration)
@@ -34,34 +32,82 @@ Vagrant.configure('2') do |config|
     # Kernel Image ID
     # [str] 138 if nil
     provider.kernel_id = '138'
-
-    # Networking (Optional Configuration)
-
-    # Enable private networking
-    # [boolean] disabled if nil
-    #provider.private_networking = true
   end
+  
 
-  config.vm.provision :shell, path: 'scripts/provision.sh'
-
-  config.vm.provision :chef_solo do |chef|
-    chef.cookbooks_path = 'cookbooks'
-    chef.add_recipe 'test'
-  end
 
   # Linode Specific Configurations
-  config.vm.define :ubuntu do |ubuntu|
-    ubuntu.vm.provider :linode do |provider|
-      provider.distribution = 'Ubuntu 14.04 LTS'
 
-      # Optional Settings
-      provider.label = 'Vagrant-Ubuntu'
+  ## Each facility gets three different machines - each of them will correspond to a 
+  ## specific set of machines.
+  ## - Hosts
+  ## - Backup Boxes
+  ## - Linode's Linodes
+
+  # Atlanta
+  config.vm.define :atlanta do |atlanta|
+    atlanta.vm.provider :linode do |provider|
+      provider.label = 'Atlanta-host-audit'
+      provider.group = 'Internal-Audit'
+      provider.datacenter = 'atlanta'
     end
   end
 
-  config.vm.define :centos do |centos|
-    centos.vm.provider :linode do |provider|
-      provider.distribution = 'CentOS 7'
+  # Dallas
+  config.vm.define :dallas do |dallas|
+    dallas.vm.provider :linode do |provider|
+      provider.label = 'Dallas-Host-Audit'
+      provider.group = 'Internal-Audit'
+      provider.datacenter = 'dallas'
     end
   end
+  
+  # Fremont
+  config.vm.define :fremont do |fremont|
+    fremont.vm.provider :linode do |provider|
+      provider.label = 'Fremont-Host-Audit'
+      provider.group = 'Internal-Audit'
+      provider.datacenter = 'fremont'
+    end
+  end
+  
+  # London
+  config.vm.define :london do |london|
+    london.vm.provider :linode do |provider|
+      provider.label = 'London-Host-Audit'
+      provider.group = 'Internal-Audit'
+      provider.datacenter = 'london'
+    end
+  end
+  
+  # Newark
+  config.vm.define :newark do |newark|
+    newark.vm.provider :linode do |provider|
+      provider.label = 'Newark-Host-Audit'
+      provider.group = 'Internal-Audit'
+      provider.datacenter = 'newark'
+    end
+  end
+  
+  # Singapore
+  config.vm.define :singapore do |singapore|
+    singapore.vm.provider :linode do |provider|
+      provider.label = 'Singapore-Host-Audit'
+      provider.group = 'Internal-Audit'
+      provider.datacenter = 'singapore'
+    end
+  end
+  
+  # Tokyo
+  config.vm.define :tokyo do |tokyo|
+    tokyo.vm.provider :linode do |provider|
+      provider.label = 'Tokyo-Host-Audit'
+      provider.group = 'Internal-Audit'
+      provider.datacenter = 'tokyo'
+    end
+  end
+  
+  ### Quick Provisioning via shell script
+  config.vm.provision :shell, path: 'scripts/provision.sh'
+
 end


### PR DESCRIPTION
This PR provides the ability to group created Linodes using `linode.update()`'s `lpm_displayGroup` field. This is exposed in the VagrantFile using the provider.group accessor, and should fix Issue #30.

In the event that a `provider.group` is not specified, the Linode simply doesn't get a display group.

- VagrantFile: example configuration stanza
```
  # Test
  config.vm.define :dallas_alpha do |dallas_alpha|
    dallas_alpha.vm.provider :linode do |provider|
      provider.label = 'Dallas-1'
      provider.group = 'Dallas'
      provider.datacenter = 'dallas'
    end
  end

  # Test
  config.vm.define :dallas_beta do |dallas_beta|
    dallas_beta.vm.provider :linode do |provider|
      provider.label = 'Dallas-2'
      provider.group = 'Dallas'
      provider.datacenter = 'dallas'
    end
  end
```

##### Gratuitous manager shot
--------------------
 
![alt tag](http://i.imgur.com/rFWovjf.png)