### PR TITLE
actions/create.rb: Expose hooks for display group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The following attributes are available to further configure the provider:
   reusable snapshots with user accounts already provisioned, set to `false`.
 - `provider.label` - A string representing the Linode label to assign when
   creating a new linode
+- `provider.group` - A string representing the Linode's Display group to assign
+  when creating a new linode
 
 The provider will create a new user account with the specified SSH key for
 authorization if `config.ssh.username` is set and the `provider.setup`

--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -137,9 +137,13 @@ module VagrantPlugins
           label = label || @machine.name if @machine.name != 'default'
           label = label || get_server_name
 
+          group = @machine.provider_config.group
+          group = "" if @machine.provider_config.group == false
+
           result = @client.linode.update(
             linodeid: result['linodeid'],
-            label: label
+            label: label,
+            lpm_displaygroup: group
           )
 
           env[:ui].info I18n.t('vagrant_linode.info.booting', linodeid: result['linodeid'])

--- a/lib/vagrant-linode/config.rb
+++ b/lib/vagrant-linode/config.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :swap_size
       attr_accessor :kernel_id
       attr_accessor :label
+      attr_accessor :group
 
       alias_method :setup?, :setup
 
@@ -33,6 +34,7 @@ module VagrantPlugins
         @swap_size          = UNSET_VALUE
         @kernel_id          = UNSET_VALUE
         @label              = UNSET_VALUE
+        @group              = UNSET_VALUE
       end
 
       def finalize!
@@ -50,6 +52,7 @@ module VagrantPlugins
         @swap_size          = '256' if @swap_size == UNSET_VALUE
         @kernel_id          = '138' if @kernel_id == UNSET_VALUE
         @label              = false if @label == UNSET_VALUE
+        @group              = false if @group == UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
This PR introduces the ability to group created Linodes using linode.update()'s lpm_displayGroup field. This is exposed in the VagrantFile using the provider.group accessor, and should fix Issue #30.

In the event that a provider.group is not specified, the Linode simply doesn't get a display group.


- VagrantFile: example configuration stanza
```
  # Test
  config.vm.define :dallas_alpha do |dallas_alpha|
    dallas_alpha.vm.provider :linode do |provider|
      provider.label = 'Dallas-1'
      provider.group = 'Dallas'
      provider.datacenter = 'dallas'
    end
  end

  # Test
  config.vm.define :dallas_beta do |dallas_beta|
    dallas_beta.vm.provider :linode do |provider|
      provider.label = 'Dallas-2'
      provider.group = 'Dallas'
      provider.datacenter = 'dallas'
    end
  end
```

#### Gratuitous manager shot
![alt tag](http://i.imgur.com/rFWovjf.png)