### PR TITLE
Add support for using an ImageID

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Vagrant.configure('2') do |config|
     # provider.paymentterm = <*1*,12,24>
     # provider.datacenterid = <int>
     # provider.image = <string>
-    # provider.imageid = <int>
+    # provider.image_id = <int>
     # provider.kernel = <string>
     # provider.kernelid = <int>
     # provider.private_networking = <boolean>

--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -38,6 +38,14 @@ module VagrantPlugins
             distribution_id = @machine.provider_config.distributionid
           end
 
+          if @machine.provider_config.image_id
+            distribution_id = nil
+            images = @client.image.list
+            image = images.find { |i| i.imageid == @machine.provider_config.image_id }
+            fail(Errors::ImageMatch, distro: @machine.provider_config.image_id.to_s) if image.nil?
+            image_id = image.imageid || nil
+          end
+
           if @machine.provider_config.kernel
             kernels = @client.avail.kernels
             kernel = kernels.find { |k| k.label.downcase.include? @machine.provider_config.kernel.downcase }
@@ -114,6 +122,7 @@ module VagrantPlugins
             disk = @client.linode.disk.createfromimage(
               linodeid: result['linodeid'],
               imageid: image_id,
+              label: 'Vagrant Disk Image (' + image_id + ') for ' + result['linodeid'].to_s,
               size: xvda_size,
               rootsshkey: pubkey,
               rootpass: root_pass

--- a/lib/vagrant-linode/config.rb
+++ b/lib/vagrant-linode/config.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
       attr_accessor :api_key
       attr_accessor :api_url
       attr_accessor :distribution
+      attr_accessor :image_id
       attr_accessor :datacenter
       attr_accessor :plan
       attr_accessor :paymentterm
@@ -28,6 +29,7 @@ module VagrantPlugins
         @api_key            = UNSET_VALUE
         @api_url            = UNSET_VALUE
         @distribution       = UNSET_VALUE
+        @image_id           = UNSET_VALUE
         @datacenter         = UNSET_VALUE
         @plan               = UNSET_VALUE
         @paymentterm        = UNSET_VALUE
@@ -49,6 +51,7 @@ module VagrantPlugins
         @api_key            = @token if ((@api_key == nil) and (@token != nil))
         @api_url            = ENV['LINODE_URL'] if @api_url == UNSET_VALUE
         @distribution       = 'Ubuntu 14.04 LTS' if @distribution == UNSET_VALUE
+        @image_id           = nil if @image_id == UNSET_VALUE
         @datacenter         = 'dallas' if @datacenter == UNSET_VALUE
         @plan               = 'Linode 1024' if @plan == UNSET_VALUE
         @paymentterm        = '1' if @paymentterm == UNSET_VALUE


### PR DESCRIPTION
Add support for using an ImageID.  If an ImageID is specified, try to find it.  If it finds it, null out `distribution_id` so `elsif image_id` is used instead.
