### PR TITLE
Add support for Linode StackScripts via the stackscript/stackscriptid attributes

### DIFF
--- a/lib/vagrant-linode/config.rb
+++ b/lib/vagrant-linode/config.rb
@@ -17,6 +17,9 @@ module VagrantPlugins
       attr_accessor :ca_path
       attr_accessor :ssh_key_name
       attr_accessor :setup
+      attr_accessor :stackscriptid
+      attr_accessor :stackscript
+      attr_accessor :stackscript_udf_responses
       attr_accessor :xvda_size
       attr_accessor :swap_size
       attr_accessor :kernelid
@@ -34,6 +37,9 @@ module VagrantPlugins
         @api_url            = UNSET_VALUE
         @distributionid     = UNSET_VALUE
         @distribution       = UNSET_VALUE
+        @stackscriptid      = UNSET_VALUE
+        @stackscript        = UNSET_VALUE
+        @stackscript_udf_responses = UNSET_VALUE
         @imageid            = UNSET_VALUE
 	@image              = UNSET_VALUE
 	@datacenterid       = UNSET_VALUE
@@ -63,6 +69,9 @@ module VagrantPlugins
         @distributionid     = nil if @distributionid == UNSET_VALUE
 	@distribution       = nil if @distribution == UNSET_VALUE
         @distribution       = 'Ubuntu 14.04 LTS' if @distribution.nil? and @distributionid.nil? and @imageid.nil? and @image.nil?
+        @stackscriptid      = nil if @stackscriptid == UNSET_VALUE
+        @stackscript        = nil if @stackscript == UNSET_VALUE
+        @stackscript_udf_responses = nil if @stackscript_udf_responses == UNSET_VALUE
         @datacenterid       = nil if @datacenterid == UNSET_VALUE
         @datacenter         = nil if @datacenter == UNSET_VALUE
         @datacenter         = 'dallas' if @datacenter.nil? and @datacenterid.nil?
@@ -100,6 +109,10 @@ module VagrantPlugins
 	if @distributionid and @distribution
 	  errors << I18n.t('vagrant_linode.config.distributionid_or_distribution')
 	end
+
+        if @stackscriptid and @stackscript
+          errors << I18n.t('vagrant_linode.config.stackscriptid_or_stackscript')
+        end
 
 	if @datacenterid and @datacenter
 	  errors << I18n.t('vagrant_linode.config.datacenterid_or_datacenter')

--- a/lib/vagrant-linode/errors.rb
+++ b/lib/vagrant-linode/errors.rb
@@ -56,6 +56,14 @@ module VagrantPlugins
       class RsyncError < LinodeError
         error_key(:rsync)
       end
+
+      class StackscriptMatch < LinodeError
+        error_key(:stackscript_match)
+      end
+
+      class StackscriptUDFFormat < LinodeError
+        error_key(:stackscript_udf_responses)
+      end
     end
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -46,6 +46,7 @@ en:
       disk_too_large: "Disk Images use more drive space than plan allocates"
       planid_or_plan: "Use either planid or plan, not both"
       distributionid_or_distribution: "Use either distributionid or distribution, not both"
+      stackscriptid_or_stackscript: "Use either stackscriptid or stackscript, not both"
       datacenterid_or_datacenter: "Use either datacenterid or datacenter, not both"
       kernelid_or_kernel: "Use either kernelid or kernel, not both"
       imageid_or_image: "Use either imageid or image, not both"
@@ -126,3 +127,8 @@ en:
       plan_id: !-
         The plan which you have specified ( %{plan} ) is not available at this time,
         for more information regarding plans review the following url - https://www.linode.com/pricing
+      stackscript_match: !-
+        The provider does not have your chosen Stackscript ( %{stackscript} ).
+        Supported distributions can be found at the following url - https://manager.linode.com/stackscripts
+      stackscript_udf_responses: !-
+        The stackscript UDF responses object provided is of the wrong type. It should be a Hash.


### PR DESCRIPTION
These are shown in the documentation as examples but aren't functional. This patch enables that functionality.

Stackscripts are available in both public and private contexts. Names are done with a direct match to avoid false matches in the order of private and then public.

An additional `stackscript_udf_responses` argument is added to conform with the Linode API specification for [`createfromstackscript`](https://www.linode.com/api/linode/linode.disk.createfromstackscript) as this is a required parameter.