### PR TITLE
log linodeapi error details

### DIFF
--- a/lib/vagrant-linode/actions/connect_linode.rb
+++ b/lib/vagrant-linode/actions/connect_linode.rb
@@ -1,4 +1,5 @@
 require 'log4r'
+require "vagrant-linode/client_wrapper"
 
 module VagrantPlugins
   module Linode
@@ -25,7 +26,7 @@ module VagrantPlugins
 
           @logger.info('Connecting to Linode api_url...')
 
-          linode = ::LinodeAPI::Retryable.new params
+          linode = ClientWrapper.new(::LinodeAPI::Retryable.new(params), env[:ui])
           env[:linode_api] = linode
 
           @app.call(env)

--- a/lib/vagrant-linode/client_wrapper.rb
+++ b/lib/vagrant-linode/client_wrapper.rb
@@ -3,21 +3,21 @@ require "log4r"
 module VagrantPlugins
   module Linode
     class ClientWrapper
-      def initialize(client, ui)
+      def initialize(client, logger)
         @client = client
-        @ui = ui
+        @logger = logger
       end
 
       def method_missing(method, *args, &block)
         result = @client.send(method, *args, &block)
 
         if result.is_a? LinodeAPI::Retryable
-          self.class.new(result, @ui)
+          self.class.new(result, @logger)
         else
           result
         end
       rescue ::LinodeAPI::APIError => e
-        @ui.error e.details.inspect
+        @logger.error e.details.inspect
         raise
       end
     end

--- a/lib/vagrant-linode/client_wrapper.rb
+++ b/lib/vagrant-linode/client_wrapper.rb
@@ -1,0 +1,25 @@
+require "log4r"
+
+module VagrantPlugins
+  module Linode
+    class ClientWrapper
+      def initialize(client, ui)
+        @client = client
+        @ui = ui
+      end
+
+      def method_missing(method, *args, &block)
+        result = @client.send(method, *args, &block)
+
+        if result.is_a? LinodeAPI::Retryable
+          self.class.new(result, @ui)
+        else
+          result
+        end
+      rescue ::LinodeAPI::APIError => e
+        @ui.error e.details.inspect
+        raise
+      end
+    end
+  end
+end


### PR DESCRIPTION
I made this change as part of implementing volumes handling.

The plugin would not print useful API error details. This PR addresses #83.

Original output:

```
==> image_builder: Linode has not been created
==> image_builder: Creating a new linode...
==> image_builder: Created a new linode... 4566322, https://manager.linode.com/linodes/dashboard/linode4566322
/home/crome/.vagrant.d/gems/2.3.3/gems/linodeapi-2.0.1/lib/linodeapi/helpers.rb:23:in `parse': API Error encountered (LinodeAPI::APIError)
```

With error handling:

```
==> image_builder: Linode has not been created
==> image_builder: Creating a new linode...
==> image_builder: Created a new linode... 4566322, https://manager.linode.com/linodes/dashboard/linode4566322
==> image_builder: [{"ERRORMESSAGE"=>"The Block Storage beta is currently at capacity. Please try again later.", "ERRORCODE"=>8}]
/home/crome/.vagrant.d/gems/2.3.3/gems/linodeapi-2.0.1/lib/linodeapi/helpers.rb:23:in `parse': API Error encountered (LinodeAPI::APIError)
```