### PR TITLE
Add support for volumes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format doc
 --require spec_helper
+--order random

--- a/.rspec
+++ b/.rspec
@@ -1,7 +1,2 @@
---format
-doc
---order
-random
---color
---fail-fast
---backtrace
+--format doc
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,10 @@ group :development do
   gem 'pry'
 end
 
+group :test do
+  gem 'rspec-its'
+end
+
 group :plugins do
   gemspec
 end

--- a/README.md
+++ b/README.md
@@ -176,9 +176,27 @@ curl -X POST "https://api.linode.com/?api_action=avail.kernels" \
 
 More detail: [Linode API - Kernels](https://www.linode.com/api/utility/avail.kernels)
 
+### provider.volumes - [Volume Handling](https://www.linode.com/docs/platform/how-to-use-block-storage-with-your-linode/)
+
+The plugin can create and attach additional volumes when creating Linodes. `vagrant rebuild` calls will rebuild the VM only and reattach the volume afterwards without losing the contents.
+
+```rb
+config.vm.provider :linode do |linode|
+  linode.plan = "Linode 2048"
+  linode.volumes = [
+    {label: "extra_volume", size: 1},
+  ]
+end
+```
+
+NOTES:
+* The volume needs to be formatted and mounted inside the VM either manually or by a StackScript, etc.
+* The plugin doesn't do any volume metadata management. If a volume is renamed the next `vagrant up` call will create a new one.
+* Running `vagrant destroy` will **NOT** destroy the volumes.
+
 ### nfs.functional
 
-The sync provider, NFS, has been disabled to make rsync easier to use.  To enable NFS, 
+The sync provider, NFS, has been disabled to make rsync easier to use.  To enable NFS,
 run Vagrant with an environment variable `LINODE_NFS_FUNCTIONAL=1`.  This will require
 a bit more configuration between the Linode and the Vagrant host.
 
@@ -193,7 +211,7 @@ command:
 This command will create a new linode, setup your SSH key for authentication,
 create a new user account, and run the provisioners you have configured.
 
-The  environment variable `VAGRANT_DEFAULT_PROVIDER` can be set to `linode` to avoid sending `--provider=linode` on each `vagrant up`. 
+The  environment variable `VAGRANT_DEFAULT_PROVIDER` can be set to `linode` to avoid sending `--provider=linode` on each `vagrant up`.
 
 **Supported Commands**
 

--- a/lib/vagrant-linode/actions.rb
+++ b/lib/vagrant-linode/actions.rb
@@ -256,6 +256,14 @@ module VagrantPlugins
         end
       end
 
+      def self.action_list_volumes
+        Vagrant::Action::Builder.new.tap do |b|
+          # b.use ConfigValidate # is this per machine?
+          b.use ConnectLinode
+          b.use ListVolumes
+        end
+      end
+
       action_root = Pathname.new(File.expand_path('../actions', __FILE__))
       autoload :ConnectLinode, action_root.join('connect_linode')
       autoload :ReadState, action_root.join('read_state')
@@ -284,6 +292,7 @@ module VagrantPlugins
       autoload :ListDistributions, action_root.join('list_distributions')
       autoload :ListKernels, action_root.join('list_kernels')
       autoload :ListDatacenters, action_root.join('list_datacenters')
+      autoload :ListVolumes, action_root.join('list_volumes')
     end
   end
 end

--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -225,7 +225,7 @@ module VagrantPlugins
               )
               env[:ui].info "volume #{volume_name} attached"
             else
-              raise Errors::VolumeSizeMissing unless volume[:size] && volume[:size].to_i > 0
+              raise Errors::VolumeSizeMissing unless volume[:size].to_i > 0
               @client.volume.create(
                 size: volume[:size],
                 label: volume_name,

--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -122,21 +122,21 @@ module VagrantPlugins
             datacenterid: datacenter_id,
             paymentterm: @machine.provider_config.paymentterm || 1
           )
-          env[:ui].info I18n.t('vagrant_linode.info.created', linodeid: result['linodeid'], label: (@machine.provider_config.label or "linode#{result['linodeid']}"))
-
-          # @client.linode.job.list(:linodeid => result['linodeid'], :pendingonly => 1)
-          # assign the machine id for reference in other commands
           @machine.id = result['linodeid'].to_s
+          env[:ui].info I18n.t('vagrant_linode.info.created', linodeid: @machine.id, label: (@machine.provider_config.label or "linode#{@machine.id}"))
+
+          # @client.linode.job.list(:linodeid => @machine.id, :pendingonly => 1)
+          # assign the machine id for reference in other commands
 
           disklist = []
 
           if stackscript_id
             disk = @client.linode.disk.createfromstackscript(
-              linodeid: result['linodeid'],
+              linodeid: @machine.id,
               stackscriptid: stackscript_id,
               stackscriptudfresponses: JSON.dump(stackscript_udf_responses),
               distributionid: distribution_id,
-              label: 'Vagrant Disk Distribution ' + distribution_id.to_s + ' Linode ' + result['linodeid'].to_s,
+              label: 'Vagrant Disk Distribution ' + distribution_id.to_s + ' Linode ' + @machine.id,
               type: 'ext4',
               size: xvda_size,
               rootsshkey: pubkey,
@@ -145,9 +145,9 @@ module VagrantPlugins
             disklist.push(disk['diskid'])
           elsif distribution_id
             disk = @client.linode.disk.createfromdistribution(
-              linodeid: result['linodeid'],
+              linodeid: @machine.id,
               distributionid: distribution_id,
-              label: 'Vagrant Disk Distribution ' + distribution_id.to_s + ' Linode ' + result['linodeid'].to_s,
+              label: 'Vagrant Disk Distribution ' + distribution_id.to_s + ' Linode ' + @machine.id,
               type: 'ext4',
               size: xvda_size,
               rootsshkey: pubkey,
@@ -156,9 +156,9 @@ module VagrantPlugins
             disklist.push(disk['diskid'])
           elsif image_id
             disk = @client.linode.disk.createfromimage(
-              linodeid: result['linodeid'],
+              linodeid: @machine.id,
               imageid: image_id,
-              label: 'Vagrant Disk Image (' + image_id.to_s + ') for ' + result['linodeid'].to_s,
+              label: 'Vagrant Disk Image (' + image_id.to_s + ') for ' + @machine.id,
               size: xvda_size,
               rootsshkey: pubkey,
               rootpass: root_pass
@@ -170,7 +170,7 @@ module VagrantPlugins
 
           if swap_size > 0
             swap = @client.linode.disk.create(
-              linodeid: result['linodeid'],
+              linodeid: @machine.id,
               label: 'Vagrant swap',
               type: 'swap',
               size: swap_size
@@ -183,8 +183,8 @@ module VagrantPlugins
           if xvdc_size > 0
             xvdc_type = @machine.provider_config.xvdc_type.is_a?(Vagrant::Config::V2::DummyConfig) ? "raw" : @machine.provider_config.xvdc_type
             xvdc = @client.linode.disk.create(
-              linodeid: result['linodeid'],
-              label: 'Vagrant Leftover Disk Linode ' + result['linodeid'].to_s,
+              linodeid: @machine.id,
+              label: 'Vagrant Leftover Disk Linode ' + @machine.id,
               type: xvdc_type,
               size: xvdc_size,
             )
@@ -194,7 +194,7 @@ module VagrantPlugins
           end
 
           config = @client.linode.config.create(
-            linodeid: result['linodeid'],
+            linodeid: @machine.id,
             label: 'Vagrant Config',
             disklist: disklist.join(','),
             kernelid: kernel_id
@@ -202,7 +202,7 @@ module VagrantPlugins
 
           # @todo: allow provisioning to set static configuration for networking
           if @machine.provider_config.private_networking
-            private_network = @client.linode.ip.addprivate linodeid: result['linodeid']
+            private_network = @client.linode.ip.addprivate linodeid: @machine.id
           end
 
           label = @machine.provider_config.label
@@ -213,15 +213,15 @@ module VagrantPlugins
           group = "" if @machine.provider_config.group == false
 
           result = @client.linode.update(
-            linodeid: result['linodeid'],
+            linodeid: @machine.id,
             label: label,
             lpm_displaygroup: group
           )
 
-          env[:ui].info I18n.t('vagrant_linode.info.booting', linodeid: result['linodeid'])
+          env[:ui].info I18n.t('vagrant_linode.info.booting', linodeid: @machine.id)
 
-          bootjob = @client.linode.boot linodeid: result['linodeid']
-          # sleep 1 until ! @client.linode.job.list(:linodeid => result['linodeid'], :jobid => bootjob['jobid'], :pendingonly => 1).length
+          bootjob = @client.linode.boot linodeid: @machine.id
+          # sleep 1 until ! @client.linode.job.list(:linodeid => @machine.id, :jobid => bootjob['jobid'], :pendingonly => 1).length
           wait_for_event(env, bootjob['jobid'])
 
           # refresh linode state with provider and output ip address

--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -214,6 +214,7 @@ module VagrantPlugins
 
           existing_volumes = @client.volume.list
           @machine.provider_config.volumes.each do |volume|
+            raise Errors::VolumeLabelMissing unless volume[:label]
             volume_name = "#{@machine.name}_#{volume[:label]}"
 
             remote_volume = existing_volumes.find { |v| v.label == volume_name }

--- a/lib/vagrant-linode/actions/create.rb
+++ b/lib/vagrant-linode/actions/create.rb
@@ -212,6 +212,18 @@ module VagrantPlugins
           group = @machine.provider_config.group
           group = "" if @machine.provider_config.group == false
 
+          @machine.provider_config.volumes.each_with_index do |volume, i|
+            volume_name = "#{@machine.name}_volume_#{i}",
+            result = @client.volume.create(
+              size: volume[:size],
+              label: volume_name,
+              datacenterid: datacenter_id,
+              linodeid: @machine.id
+            )
+
+            env[:ui].info "disk #{volume_name} created"
+          end
+
           result = @client.linode.update(
             linodeid: @machine.id,
             label: label,

--- a/lib/vagrant-linode/actions/list_volumes.rb
+++ b/lib/vagrant-linode/actions/list_volumes.rb
@@ -19,11 +19,11 @@ module VagrantPlugins
             remote_volume = remote_volumes.find { |v| v.label == volume_label }
 
             if remote_volume.nil?
-              logger.info "volume \"%s\": %s" % [volume[:label], "does not exist"]
+              logger.info format_volume(volume_label, "does not exist")
               next
             end
 
-            logger.info format_volume(machine, remote_volume)
+            logger.info format_volume(volume_label, volume_state(machine, remote_volume))
           end
 
           @app.call(env)
@@ -31,16 +31,18 @@ module VagrantPlugins
 
         private
 
-        def format_volume(machine, volume)
-          volume_state = if volume.linodeid.to_s == machine.id
-                           "attached"
-                         elsif volume.linodeid == 0
-                           "detached"
-                         else
-                           "attached to other VM"
-                         end
+        def volume_state(machine, volume)
+          if volume.linodeid.to_s == machine.id
+            "attached"
+          elsif volume.linodeid == 0
+            "detached"
+          else
+            "attached to other VM"
+          end
+        end
 
-          "volume \"%s\": %s" % [volume.label, volume_state]
+        def format_volume(label, state)
+          "volume \"%s\": %s" % [label, state]
         end
       end
     end

--- a/lib/vagrant-linode/actions/list_volumes.rb
+++ b/lib/vagrant-linode/actions/list_volumes.rb
@@ -1,0 +1,47 @@
+module VagrantPlugins
+  module Linode
+    module Actions
+      class ListVolumes
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          api = env[:linode_api]
+          logger = env[:ui]
+          machine = env[:machine]
+
+          remote_volumes = api.volume.list
+          volume_definitions = machine.provider_config.volumes
+
+          volume_definitions.each do |volume|
+            remote_volume = remote_volumes.find { |v| v.label == volume[:label] }
+
+            if remote_volume.nil?
+              logger.info "volume \"%s\": %s" % [volume[:label], "does not exist"]
+              next
+            end
+
+            logger.info format_volume(machine, remote_volume)
+          end
+
+          @app.call(env)
+        end
+
+        private
+
+        def format_volume(machine, volume)
+          volume_state = if volume.linodeid == machine.id
+                           "attached"
+                         elsif volume.linodeid == 0
+                           "detached"
+                         else
+                           "attached to other VM"
+                         end
+
+          "volume \"%s\": %s" % [volume.label, volume_state]
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-linode/actions/list_volumes.rb
+++ b/lib/vagrant-linode/actions/list_volumes.rb
@@ -15,7 +15,8 @@ module VagrantPlugins
           volume_definitions = machine.provider_config.volumes
 
           volume_definitions.each do |volume|
-            remote_volume = remote_volumes.find { |v| v.label == volume[:label] }
+            volume_label = "#{machine.name}_#{volume[:label]}"
+            remote_volume = remote_volumes.find { |v| v.label == volume_label }
 
             if remote_volume.nil?
               logger.info "volume \"%s\": %s" % [volume[:label], "does not exist"]

--- a/lib/vagrant-linode/actions/list_volumes.rb
+++ b/lib/vagrant-linode/actions/list_volumes.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
         private
 
         def format_volume(machine, volume)
-          volume_state = if volume.linodeid == machine.id
+          volume_state = if volume.linodeid.to_s == machine.id
                            "attached"
                          elsif volume.linodeid == 0
                            "detached"

--- a/lib/vagrant-linode/actions/rebuild.rb
+++ b/lib/vagrant-linode/actions/rebuild.rb
@@ -238,6 +238,28 @@ module VagrantPlugins
           group = @machine.provider_config.group
           group = "" if @machine.provider_config.group == false
 
+          existing_volumes = @client.volume.list
+          @machine.provider_config.volumes.each do |volume|
+            volume_name = "#{@machine.name}_#{volume[:label]}"
+
+            remote_volume = existing_volumes.find { |v| v.label == volume_name }
+            if remote_volume
+              @client.volume.update(
+                volumeid: remote_volume.volumeid,
+                linodeid: @machine.id
+              )
+              env[:ui].info "volume #{volume_name} attached"
+            else
+              raise Errors::VolumeSizeMissing unless volume[:size] && volume[:size].to_i > 0
+              @client.volume.create(
+                size: volume[:size],
+                label: volume_name,
+                linodeid: @machine.id
+              )
+              env[:ui].info "volume #{volume_name} created and attached"
+            end
+          end
+
           result = @client.linode.update(
             linodeid: @machine.id,
             label: label,

--- a/lib/vagrant-linode/actions/rebuild.rb
+++ b/lib/vagrant-linode/actions/rebuild.rb
@@ -101,7 +101,7 @@ module VagrantPlugins
             fail Errors::PlanID, plan: @machine.provider_config.planid if plan.nil?
             plan_id = @machine.provider_config.planid
           end
-          
+
           ### Disk Images
           xvda_size, swap_size, disk_sanity = @machine.provider_config.xvda_size, @machine.provider_config.swap_size, true
 
@@ -143,7 +143,7 @@ module VagrantPlugins
               jobid: job
             )
 
-            while jobStatus[0]['host_finish_dt'].nil? || jobStatus[0]['host_finish_dt'].empty? do 
+            while jobStatus[0]['host_finish_dt'].nil? || jobStatus[0]['host_finish_dt'].empty? do
               sleep(5)
               jobStatus = @client.linode.job.list(
                 linodeid: @machine.id,
@@ -298,7 +298,7 @@ module VagrantPlugins
 
           @app.call(env)
         end
-        
+
         def get_server_name
           "vagrant_linode-#{rand.to_s.split('.')[1]}"
         end

--- a/lib/vagrant-linode/actions/rebuild.rb
+++ b/lib/vagrant-linode/actions/rebuild.rb
@@ -240,6 +240,7 @@ module VagrantPlugins
 
           existing_volumes = @client.volume.list
           @machine.provider_config.volumes.each do |volume|
+            raise Errors::VolumeLabelMissing unless volume[:label]
             volume_name = "#{@machine.name}_#{volume[:label]}"
 
             remote_volume = existing_volumes.find { |v| v.label == volume_name }

--- a/lib/vagrant-linode/actions/rebuild.rb
+++ b/lib/vagrant-linode/actions/rebuild.rb
@@ -251,7 +251,7 @@ module VagrantPlugins
               )
               env[:ui].info "volume #{volume_name} attached"
             else
-              raise Errors::VolumeSizeMissing unless volume[:size] && volume[:size].to_i > 0
+              raise Errors::VolumeSizeMissing unless volume[:size].to_i > 0
               @client.volume.create(
                 size: volume[:size],
                 label: volume_name,

--- a/lib/vagrant-linode/actions/rebuild.rb
+++ b/lib/vagrant-linode/actions/rebuild.rb
@@ -1,6 +1,7 @@
 require 'vagrant-linode/helpers/client'
 require 'vagrant-linode/helpers/waiter'
 require 'vagrant-linode/errors'
+require 'vagrant-linode/services/volume_manager'
 
 module VagrantPlugins
   module Linode
@@ -238,28 +239,7 @@ module VagrantPlugins
           group = @machine.provider_config.group
           group = "" if @machine.provider_config.group == false
 
-          existing_volumes = @client.volume.list
-          @machine.provider_config.volumes.each do |volume|
-            raise Errors::VolumeLabelMissing unless volume[:label]
-            volume_name = "#{@machine.name}_#{volume[:label]}"
-
-            remote_volume = existing_volumes.find { |v| v.label == volume_name }
-            if remote_volume
-              @client.volume.update(
-                volumeid: remote_volume.volumeid,
-                linodeid: @machine.id
-              )
-              env[:ui].info "volume #{volume_name} attached"
-            else
-              raise Errors::VolumeSizeMissing unless volume[:size].to_i > 0
-              @client.volume.create(
-                size: volume[:size],
-                label: volume_name,
-                linodeid: @machine.id
-              )
-              env[:ui].info "volume #{volume_name} created and attached"
-            end
-          end
+          Services::VolumeManager.new(@machine, @client.volume, env[:ui]).perform
 
           result = @client.linode.update(
             linodeid: @machine.id,

--- a/lib/vagrant-linode/commands/list_volumes.rb
+++ b/lib/vagrant-linode/commands/list_volumes.rb
@@ -1,0 +1,20 @@
+module VagrantPlugins
+  module Linode
+    module Commands
+      class ListVolumes < Vagrant.plugin('2', :command)
+        def execute
+          opts = OptionParser.new do |o|
+            o.banner = 'Usage: vagrant linode volumes list [options]'
+          end
+
+          argv = parse_options(opts)
+          return unless argv
+
+          with_target_vms(argv) do |machine|
+            machine.action(:list_volumes)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-linode/commands/root.rb
+++ b/lib/vagrant-linode/commands/root.rb
@@ -40,6 +40,10 @@ module VagrantPlugins
             require File.expand_path('../servers', __FILE__)
             Servers
           end
+          @subcommands.register(:volumes) do
+            require File.expand_path('../volumes', __FILE__)
+            Volumes
+          end
 
           super(argv, env)
         end

--- a/lib/vagrant-linode/commands/volumes.rb
+++ b/lib/vagrant-linode/commands/volumes.rb
@@ -1,0 +1,55 @@
+module VagrantPlugins
+  module Linode
+    module Commands
+      class Volumes < Vagrant.plugin('2', :command)
+        def initialize(argv, env)
+          @main_args, @sub_command, @sub_args = split_main_and_subcommand(argv)
+
+          @subcommands = Vagrant::Registry.new
+          @subcommands.register(:list) do
+            require File.expand_path('../list_volumes', __FILE__)
+            ListVolumes
+          end
+
+          super(argv, env)
+        end
+
+        def execute
+          if @main_args.include?('-h') || @main_args.include?('--help')
+            # Print the help for all the rackspace commands.
+            return help
+          end
+
+          command_class = @subcommands.get(@sub_command.to_sym) if @sub_command
+          return help if !command_class || !@sub_command
+          @logger.debug("Invoking command class: #{command_class} #{@sub_args.inspect}")
+
+          # Initialize and execute the command class
+          command_class.new(@sub_args, @env).execute
+        end
+
+        def help
+          opts = OptionParser.new do |opts|
+            opts.banner = 'Usage: vagrant linode volumes <subcommand> [<args>]'
+            opts.separator ''
+            opts.separator 'Available subcommands:'
+
+            # Add the available subcommands as separators in order to print them
+            # out as well.
+            keys = []
+            @subcommands.each { |key, _value| keys << key.to_s }
+
+            keys.sort.each do |key|
+              opts.separator "     #{key}"
+            end
+
+            opts.separator ''
+            opts.separator 'For help on any individual subcommand run `vagrant linode images <subcommand> -h`'
+          end
+
+          @env.ui.info(opts.help, prefix: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-linode/commands/volumes.rb
+++ b/lib/vagrant-linode/commands/volumes.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
             end
 
             opts.separator ''
-            opts.separator 'For help on any individual subcommand run `vagrant linode images <subcommand> -h`'
+            opts.separator 'For help on any individual subcommand run `vagrant linode volumes <subcommand> -h`'
           end
 
           @env.ui.info(opts.help, prefix: false)

--- a/lib/vagrant-linode/config.rb
+++ b/lib/vagrant-linode/config.rb
@@ -26,6 +26,7 @@ module VagrantPlugins
       attr_accessor :kernel
       attr_accessor :label
       attr_accessor :group
+      attr_accessor :volumes
 
       alias_method :setup?, :setup
 
@@ -57,6 +58,7 @@ module VagrantPlugins
         @kernel             = UNSET_VALUE
         @label              = UNSET_VALUE
         @group              = UNSET_VALUE
+        @volumes            = UNSET_VALUE
       end
 
       def finalize!
@@ -90,6 +92,7 @@ module VagrantPlugins
         @kernel             = 'Latest 64 bit' if @kernel.nil? and @kernelid.nil?
         @label              = false if @label == UNSET_VALUE
         @group              = false if @group == UNSET_VALUE
+        @volumes            = [] if @volumes == UNSET_VALUE
       end
 
       def validate(machine)
@@ -132,6 +135,10 @@ module VagrantPlugins
 
         if (@distribution or @distributionid) and (@imageid or @image)
           errors << I18n.t('vagrant_linode.config.distribution_or_image')
+        end
+
+        if !@volumes.is_a? Array
+          errors << I18n.t("vagrant_linode.config.volumes")
         end
 
         { 'Linode Provider' => errors }

--- a/lib/vagrant-linode/errors.rb
+++ b/lib/vagrant-linode/errors.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
       class DatacenterMatch < LinodeError
         error_key(:datacenter_match)
       end
- 
+
       class ImageMatch < LinodeError
         error_key(:image_match)
       end
@@ -63,6 +63,10 @@ module VagrantPlugins
 
       class StackscriptUDFFormat < LinodeError
         error_key(:stackscript_udf_responses)
+      end
+
+      class VolumeSizeMissing < LinodeError
+        error_key(:volume_size_missing)
       end
     end
   end

--- a/lib/vagrant-linode/errors.rb
+++ b/lib/vagrant-linode/errors.rb
@@ -68,6 +68,10 @@ module VagrantPlugins
       class VolumeSizeMissing < LinodeError
         error_key(:volume_size_missing)
       end
+
+      class VolumeLabelMissing < LinodeError
+        error_key(:volume_label_missing)
+      end
     end
   end
 end

--- a/lib/vagrant-linode/services/volume_manager.rb
+++ b/lib/vagrant-linode/services/volume_manager.rb
@@ -1,0 +1,59 @@
+require "vagrant-linode/errors"
+
+module VagrantPlugins
+  module Linode
+    module Services
+      class VolumeManager
+        def initialize(machine, api, logger)
+          @machine = machine
+          @volumes_api = api
+          @logger = logger
+        end
+
+        def perform
+          volume_definitions.each do |volume|
+            raise Errors::VolumeLabelMissing if volume[:label].to_s.empty?
+
+            volume_name = "#{@machine.name}_#{volume[:label]}"
+
+            remote_volume = remote_volumes.find { |v| v.label == volume_name }
+            if remote_volume
+              attach_volume(remote_volume)
+            else
+              create_and_attach_volume(volume_name, volume[:size])
+            end
+          end
+        end
+
+        private
+
+        def volume_definitions
+          @machine.provider_config.volumes
+        end
+
+        def remote_volumes
+          @_remote_volumes ||= @volumes_api.list
+        end
+
+        def attach_volume(volume)
+          @volumes_api.update(
+            volumeid: volume.volumeid,
+            linodeid: @machine.id
+          )
+          @logger.info "volume #{volume.label} attached"
+        end
+
+        def create_and_attach_volume(label, size)
+          raise Errors::VolumeSizeMissing unless size.to_i > 0
+
+          @volumes_api.create(
+            label: label,
+            size: size,
+            linodeid: @machine.id
+          )
+          @logger.info "volume #{label} created and attached"
+        end
+      end
+    end
+  end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -134,3 +134,4 @@ en:
         Supported distributions can be found at the following url - https://manager.linode.com/stackscripts
       stackscript_udf_responses: !-
         The stackscript UDF responses object provided is of the wrong type. It should be a Hash.
+      volume_size_missing: For volumes that need to be created the size has to be specified.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -135,3 +135,4 @@ en:
       stackscript_udf_responses: !-
         The stackscript UDF responses object provided is of the wrong type. It should be a Hash.
       volume_size_missing: For volumes that need to be created the size has to be specified.
+      volume_label_missing: You must specify a volume label

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -52,6 +52,7 @@ en:
       kernelid_or_kernel: "Use either kernelid or kernel, not both"
       imageid_or_image: "Use either imageid or image, not both"
       distribution_or_image: "Distribution can not be specified with Image options"
+      volumes: "Volumes must be an array of disks"
     errors:
       public_key: |-
         There was an issue reading the public key at:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -135,4 +135,4 @@ en:
       stackscript_udf_responses: !-
         The stackscript UDF responses object provided is of the wrong type. It should be a Hash.
       volume_size_missing: For volumes that need to be created the size has to be specified.
-      volume_label_missing: You must specify a volume label
+      volume_label_missing: You must specify a volume label.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,9 +17,7 @@ if ENV['COVERAGE'] != 'false'
   end
 end
 
-require 'linode'
-
-require "pry"
+require 'pry'
 require 'rspec/its'
 
 I18n.load_path << 'locales/en.yml'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ end
 require 'linode'
 
 require "pry"
+require 'rspec/its'
 
 I18n.load_path << 'locales/en.yml'
 I18n.reload!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,8 @@ if ENV['COVERAGE'] != 'false'
 end
 
 require 'linode'
+
+require "pry"
+
+I18n.load_path << 'locales/en.yml'
+I18n.reload!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 if ENV['COVERAGE'] != 'false'
   require 'simplecov'
   require 'coveralls'
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
-  ]
+  ])
   SimpleCov.start
 
   # Normally classes are lazily loaded, so any class without a test

--- a/spec/vagrant-linode/services/volume_manager_spec.rb
+++ b/spec/vagrant-linode/services/volume_manager_spec.rb
@@ -1,0 +1,42 @@
+require "vagrant-linode/services/volume_manager"
+
+describe VagrantPlugins::Linode::Services::VolumeManager do
+  subject { described_class.new(machine, client, logger) }
+  let(:provider_config) { double(:config, volumes: [{label: "testvolume", size: 3}]) }
+  let(:machine) { double(:machine, id: 123, name: "test", provider_config: provider_config) }
+  let(:logger) { double(:logger, info: nil) }
+  let(:remote_volumes) { [double(:volume, volumeid: 234, size: 3, label: "test_testvolume")] }
+  let(:client) { double(:api, list: remote_volumes) }
+
+  describe "#perform" do
+    context "when the volume label is not specified" do
+      let(:provider_config) { double(:config, volumes: [{size: 3}]) }
+      it "raises an error" do
+        expect { subject.perform }.to raise_error "You must specify a volume label."
+      end
+    end
+
+    context "when the remote volume does not exist" do
+      let(:remote_volumes) { [] }
+      it "creates the volume bound to the linode" do
+        expect(client).to receive(:create).with(label: "test_testvolume", size: 3, linodeid: 123)
+        subject.perform
+      end
+
+      context "when the size is not specified" do
+        let(:provider_config) { double(:config, volumes: [{label: "testvolume"}]) }
+        it "raises an error" do
+          expect { subject.perform }.to raise_error "For volumes that need to be created the size has to be specified."
+        end
+      end
+    end
+
+    context "when the remote volume exists" do
+      let(:remote_volumes) { [double(:volume, volumeid: 234, size: 3, label: "test_testvolume")] }
+      it "attaches the volume to the machine" do
+        expect(client).to receive(:update).with(volumeid: 234, linodeid: 123)
+        subject.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds functionality for supporting the new volumes feature on Linode.

Volumes specified in the Vagrantfile will be created and attached to the VMs. The discussion is in #82 

The Vagrantfile entry looks like this:

```rb
config.vm.provider :linode do |linode|
  linode.plan = "Linode 2048"
  linode.volumes = [
    {label: "extra_volume", size: 1},
  ]
end
```

The plugin doesn't do any volume metadata management as that functionality would be more suited for other tools such as  terraform. Volume listing is limited to the volumes specified in the Vagrantfile. Listing all volumes/creating separate volumes independently from machines would be functionality for the linode CLI.

Running `vagrant destroy` will **not** destroy the volumes.
