### PR TITLE
Add a custom prefix to the User-Agent for this plugin

### DIFF
--- a/lib/vagrant-linode/helpers/client.rb
+++ b/lib/vagrant-linode/helpers/client.rb
@@ -1,4 +1,5 @@
 require 'vagrant-linode/helpers/result'
+require 'vagrant-linode/version'
 require 'linodeapi'
 require 'json'
 require 'vagrant/util/retryable'
@@ -35,7 +36,9 @@ module VagrantPlugins
         def initialize(machine)
           @logger = Log4r::Logger.new('vagrant::linode::apiclient')
           @config = machine.provider_config
-          @client = ::LinodeAPI::Retryable.new(apikey: @config.api_key, endpoint: @config.api_url || nil)
+          @client = ::LinodeAPI::Retryable.new(apikey: @config.api_key,
+                                               endpoint: @config.api_url || nil,
+                                               user_agent_prefix: "vagrant-linode/#{VagrantPlugins::Linode::VERSION}")
         end
 
         attr_reader :client

--- a/lib/vagrant-linode/version.rb
+++ b/lib/vagrant-linode/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Linode
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end

--- a/vagrant-linode.gemspec
+++ b/vagrant-linode.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://www.github.com/displague/vagrant-linode'
   gem.summary       = gem.description
 
-  gem.add_runtime_dependency 'linodeapi', '~> 2.0.1'
+  gem.add_runtime_dependency 'linodeapi', '~> 2.0.3'
   gem.add_runtime_dependency 'log4r', '~> 1.1'
 
   gem.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
The `linodeapi` gem recently added support for an extendable
custom User-Agent to facilitate usage analytics.  This updates
the `vagrant-linode` plugin to pull in the latest version of
the `linodeapi` gem in order to inject a UA prefix that will
be added to the `linodeapi` custom UA.