### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,45 @@
-Changelog
-=========
-v0.4.0 added support for Linode Volumes
-       added `vagrant linode volumes list` command
-v0.3.0 fixes for Vagrant 2.0.1 (now requires Ruby 2.2.0+)
-       xen-only kernels are no longer available (Fixes KVM Grub options)
-       rebuild command warns / quits if Linode is not powered down
-v0.2.8 fixes for Vagrant 1.9
-v0.2.7 Update default plan (and ways to set it) and default distro
-v0.2.6 added StackScript support
-v0.2.5 destroy works when linode is already deleted
-v0.2.4 fixed the box image
-v0.2.3 fixed rsync before provision on startup
-v0.2.2 fixed provision on startup
+# Changelog
+
+## v0.4.1
+
+* fixes handling of old plan labels [#88](https://github.com/displague/vagrant-linode/issues/88)
+* adds a custom User-Agent token to support usage analytics
+
+## v0.4.0
+
+* added support for Linode Volumes
+* added `vagrant linode volumes list` command
+
+## v0.3.0
+
+* fixes for Vagrant 2.0.1 (now requires Ruby 2.2.0+)
+* xen-only kernels are no longer available (Fixes KVM Grub options)
+* rebuild command warns / quits if Linode is not powered down
+
+## v0.2.8
+
+* fixes for Vagrant 1.9
+
+## v0.2.7
+
+* Update default plan (and ways to set it) and default distro
+
+## v0.2.6
+
+* added StackScript support
+
+## v0.2.5
+
+* destroy works when linode is already deleted
+
+## v0.2.4
+
+* fixed the box image
+
+## v0.2.3
+
+* fixed rsync before provision on startup
+
+## v0.2.2
+
+* fixed provision on startup

--- a/README.md
+++ b/README.md
@@ -97,25 +97,32 @@ attribute is `true`.
 
 ### provider.plan
 
-Each Linode Tier has been assigned a Plan Identifcation Number.
-Current (Feb 2017) Plan-ID table follows:
+Each Linode Tier has been assigned a Plan Identification Number.
+Current (April 2019) Plan-ID table follows:
 
-| PlanID  | Plan                          |
-|:------- |:----------------------------- |
-|    1    |   1GB Standard (Linode 1024)  |
-|    2    |   2GB Standard (Linode 2048)  |
-|    3    |   4GB Standard (Linode 4096)  |
-|    4    |   8GB Standard (Linode 8192)  |
-|    5    |  12GB Standard (Linode 12288) |
-|    6    |  24GB Standard (Linode 24576) |
-|    7    |  48GB Standard (Linode 49152) |
-|    8    |  64GB Standard (Linode 65536) |
-|    9    |  80GB Standard (Linode 81920) |
-|   10    |  16GB HighMem (Linode 16384)  |
-|   11    |  32GB HighMem (Linode 32768)  |
-|   12    |  60GB HighMem (Linode 61440)  |
-|   13    | 100GB HighMem (Linode 102400) |
-|   14    | 200GB HighMem (Linode 204800) |
+| Plan ID | Plan Name      |
+|:------- |:-------------- |
+| 1       | Nanode 1GB     |
+| 2       | Linode 2GB     |
+| 3       | Linode 4GB     |
+| 4       | Linode 8GB     |
+| 5       | Linode 16GB    |
+| 6       | Linode 32GB    |
+| 7       | Linode 64GB    |
+| 8       | Linode 96GB    |
+| 9       | Linode 128GB   |
+| 10      | Linode 192GB   |
+| 11      | Linode 24GB    |
+| 12      | Linode 48GB    |
+| 13      | Linode 90GB    |
+| 14      | Linode 150GB   |
+| 15      | Linode 300GB   |
+| 16      | Dedicated 4GB  |
+| 17      | Dedicated 8GB  |
+| 18      | Dedicated 16GB |
+| 19      | Dedicated 32GB |
+| 20      | Dedicated 64GB |
+| 21      | Dedicated 96GB |
 
 This can be obtained through vagrant with:
 ```


### PR DESCRIPTION
* fixes handling of old plan labels [#88](https://github.com/displague/vagrant-linode/issues/88)
* adds a custom User-Agent token to support usage analytics